### PR TITLE
Changed configuration settings to use new the storage

### DIFF
--- a/ffmpeg-farm-server/API.WindowsService/App.Release.config
+++ b/ffmpeg-farm-server/API.WindowsService/App.Release.config
@@ -3,9 +3,9 @@
      see the web.config examples at http://go.microsoft.com/fwlink/?LinkId=214134. -->
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="FFmpegLogPath" value="\\onddata.net.dr.dk\cache$\MediaCache\ffmpeg-farm\logfiles\"
+    <add key="FFmpegLogPath" value="\\net.dr.dk\od$\MediaCache\ffmpeg-farm\logfiles\"
          xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
-    <add key="MediaInfoPath" value="\\onddata.net.dr.dk\cache$\MediaCache\Tools\MediaInfo.exe"
+    <add key="MediaInfoPath" value="\\net.dr.dk\od$\Tools\MediaInfo.exe"
      xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
   </appSettings>
   <nlog internalLogFile="D:\Service\FFmpegServerAPI\nlog_internallog.txt" internalLogLevel="Error" internalLogIncludeTimestamp="true"


### PR DESCRIPTION
In order to utilize the new storage and move away from onddata.net.dr.dk the config-changes for production config must change. 
The paths are already utilized by the ffmpeg-farm as output destination, which should mean that the file-share destinations are available for the service.